### PR TITLE
Adicionando paralelismo nas chamadas a API do Github

### DIFF
--- a/src/SocialAnalytics.Application/GitHubAppService.cs
+++ b/src/SocialAnalytics.Application/GitHubAppService.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using SocialAnalytics.Application.Interfaces;
 using SocialAnalytics.Application.ViewModels;
 using SocialAnalytics.Infra.ServiceAgents.GitHubApi;
@@ -43,17 +45,21 @@ namespace SocialAnalytics.Application
         {
             var countResults = new List<GitHubCountResult>();
 
-            foreach (var request in requests)
+            Parallel.ForEach(requests.Where(req => !string.IsNullOrEmpty(req.Email)), new ParallelOptions
             {
-                var countResult = new GitHubCountResult();
-                var email = request.Email + "";
-                if (email.Equals("")) continue;
-
-                countResult.Email = email;
-                countResult.Count = CountResult(GetLoginByEmail(email), type);
+                //verificar se 10 vale a pena.
+                MaxDegreeOfParallelism = 10
+            }, request =>
+            {
+                var email = request.Email;
+                var countResult = new GitHubCountResult
+                {
+                    Email = email,
+                    Count = CountResult(GetLoginByEmail(email), type)
+                };
 
                 countResults.Add(countResult);
-            }
+            });
 
             return countResults;
         }

--- a/src/SocialAnalytics.Services.REST.SocialAPI/Controllers/GitHubController.cs
+++ b/src/SocialAnalytics.Services.REST.SocialAPI/Controllers/GitHubController.cs
@@ -13,10 +13,10 @@ namespace SocialAnalytics.Services.REST.SocialAPI.Controllers
     [RoutePrefix("api/v1/github")]
     public class GitHubController : ApiController
     {
-        private readonly GitHubAppService _gitHubAppService = new GitHubAppService();
-
         private const string MessageErro = "Falha ao realizar requisição: Nenhum valor foi fornecido " +
                                            "para um ou mais parâmetros necessários.";
+
+        private readonly GitHubAppService _gitHubAppService = new GitHubAppService();
 
         [HttpPost]
         [Route("stargazers/count")]

--- a/src/SocialAnalytics.Services.REST.SocialAPI/SocialAnalytics.Services.REST.SocialAPI.csproj
+++ b/src/SocialAnalytics.Services.REST.SocialAPI/SocialAnalytics.Services.REST.SocialAPI.csproj
@@ -70,6 +70,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Http.Cors, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Cors.5.2.3\lib\net45\System.Web.Http.Cors.dll</HintPath>
       <Private>True</Private>
@@ -89,9 +92,6 @@
   <ItemGroup>
     <Reference Include="System.Net.Http.Formatting">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http.WebHost">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>


### PR DESCRIPTION
adicionei paralelismo as chamadas da api do github.

Obs1. a resposta não será na mesma ordem da chamada, isso gera problema?
Obs2. não consegui gerar métricas claras para provar que ficou mais
rapido. (vai na confiança) ou podemos tentar medir mais pra frente.
